### PR TITLE
feat: 支持 create_demo 命令指定创建目录名称

### DIFF
--- a/scripts/create_demo.ps1
+++ b/scripts/create_demo.ps1
@@ -1,8 +1,18 @@
-﻿
-for ($x=1; $x -lt 100; $x=$x+1) {
-    if (-not (Test-Path "orpm-demo-$x")) {
-        $demo = "orpm-demo-$x"
-        break
+﻿param($ProjectName)
+
+# 支持指定项目名称
+if ($ProjectName) {
+    if (-not (Test-Path $ProjectName)) {
+        $demo = $ProjectName
+    } else {
+        Write-Host "已存在同名目录: $ProjectName" -ForegroundColor Red
+    }
+} else {
+    for ($x=1; $x -lt 100; $x=$x+1) {
+        if (-not (Test-Path "orpm-demo-$x")) {
+            $demo = "orpm-demo-$x"
+            break
+        }
     }
 }
 


### PR DESCRIPTION
以创建 demo 的方式创建项目，当需要更改名称时，需要关闭 openresty 进程，方可更改。
因此支持指定目录名称创建，对于创建生产项目时减少二次更改的操作。